### PR TITLE
update dependencies, it errors out without the "account": line

### DIFF
--- a/dependencies/d2att.dependencies
+++ b/dependencies/d2att.dependencies
@@ -1,22 +1,32 @@
 [
   {
+    "account":    "CyanogenMod",
     "repository": "android_device_samsung_msm8960-common",
-    "target_path": "device/samsung/msm8960-common"
+    "target_path": "device/samsung/msm8960-common",
+    "revision":    "cm-10.1"
   },
   {
+    "account":    "CyanogenMod",
     "repository": "android_device_samsung_d2-common",
-    "target_path": "device/samsung/d2-common"
+    "target_path": "device/samsung/d2-common",
+    "revision":    "cm-10.1"
   },
   {
-    "repository": "android_device_samsung_d2spr",
-    "target_path": "device/samsung/d2att"
+    "account":    "CyanogenMod",
+    "repository": "android_device_samsung_d2att",
+    "target_path": "device/samsung/d2att",
+    "revision":    "cm-10.1"
   },
   {
+    "account":    "CyanogenMod",
     "repository": "android_device_samsung_qcom-common",
-    "target_path": "device/samsung/qcom-common"
+    "target_path": "device/samsung/qcom-common",
+    "revision":    "cm-10.1"
   },
   {
+    "account":    "CyanogenMod",
     "repository": "android_kernel_samsung_d2",
-    "target_path": "kernel/samsung/d2"
+    "target_path": "kernel/samsung/d2",
+    "revision":    "cm-10.1"
   }
 ]


### PR DESCRIPTION
Sending it as a pull request for the device maintainer to approve.
The device tree was also pulling from: android_device_samsung_d2spr
and renaming it to device/samsung/d2att
