### PR TITLE
p990: don't use my dev repos

### DIFF
--- a/dependencies/p990.dependencies
+++ b/dependencies/p990.dependencies
@@ -15,17 +15,17 @@
     },
     {
         "remote": "github",
-        "account": "tonypp",
+        "account": "p990-dev",
         "repository": "android_device_lge_p990",
         "target_path": "device/lge/p990",
-        "revision": "cm10.1-newbl-dev"
+        "revision": "cm-10.1-newbl"
     },
     {
         "remote": "github",
-        "account": "tonypp",
+        "account": "p990-dev",
         "repository": "android_device_lge_star-common",
         "target_path": "device/lge/star-common",
-        "revision": "cm10.1-newbl-dev"
+        "revision": "cm-10.1-newbl"
     },
     {
         "remote":       "aosp",

--- a/manifest/p990.adds
+++ b/manifest/p990.adds
@@ -12,19 +12,5 @@
         "repository":   "lge-kernel-star",
         "target_path":  "kernel/lge/star",
         "branch":       "cm-10.1"
-    },
-    {
-        "remote": "github",
-        "account": "tonypp",
-        "repository": "android_device_lge_p990",
-        "target_path": "device/lge/p990",
-        "revision": "cm10.1-newbl-dev"
-    },
-    {
-        "remote": "github",
-        "account": "tonypp",
-        "repository": "android_device_lge_star-common",
-        "target_path": "device/lge/star-common",
-        "revision": "cm10.1-newbl-dev"
     }
 ]


### PR DESCRIPTION
@metaiiica pointed the p990 to my dev repos (13290c7 and 9b855e4).
Do not use them, please - they're tagged as dev for a reason.
I'm experimenting there, they can (and will) break builds.

I'm maintaining clean repos at @p990-dev - just use them.

Signed-off-by: tonyp tonyptonyp@gmail.com
