### PR TITLE
Prebuilt pa_nav_xhdpi preferences

### DIFF
--- a/prebuilt/pa/preferences/pa_nav_xhdpi/0_colors.xml
+++ b/prebuilt/pa/preferences/pa_nav_xhdpi/0_colors.xml
@@ -1,0 +1,19 @@
+<property name="PA Colors" active="true" color="#ed4f36">
+
+        <description><![CDATA[
+            This preset will color a couple of apps. Keep in mind this is only a preset, define your own colors app per app if you like.
+        ]]></description>
+        <setting type="Hybrid" target="com.cyanogenmod.trebuchet.colors" value="4A000000|B2FFFFFF|FFFFFFFF|4A000000|FF33B5E5"/>
+        <setting type="Hybrid" target="com.android.vending.colors" value="FF121212|D1DC8745|FFB5D67E|FF121212|E5C1534E"/>
+        <setting type="Hybrid" target="com.facebook.katana.colors" value="FF28395F|B2FFFFFF|FFFFFFFF|FF375180|93FFFFFF"/>
+        <setting type="Hybrid" target="com.android.mms.colors" value="FF222222|B2FFFFFF|FFFFFFFF|FF555555|B294B829"/>
+        <setting type="Hybrid" target="com.google.android.calendar.colors" value="FF44B9E5|FFFFFFFF|FFFFFFFF|FFDDDDDD|FF44B9E5"/>
+        <setting type="Hybrid" target="com.google.android.talk.colors" value="FF222222|B2FFFFFF|FFFFFFFF|FF222222|B2FF8801"/>
+        <setting type="Hybrid" target="com.sand.airdroid.colors" value="FFF4F6F7|B260A517|FF000000|FF96DF4B|FFFFFFFF"/>
+        <setting type="Hybrid" target="com.google.android.googlequicksearchbox.colors" value="FFE5E5E5|B234B4E3|FFFFFFFF|FFE5E5E5|FF33B5E5"/>
+        <setting type="Hybrid" target="com.google.android.apps.plus.colors" value="FFDDDDDD|B2777777|FFFFFFFF|FFDDDDDD|FF33B5E5"/>
+        <setting type="Hybrid" target="com.verge.android.colors" value="FFFFFFFF|FFFA4D2A|FFAA66CC|FFFA4D2A|FFFFFFFF"/>
+        <setting type="Hybrid" target="com.google.android.youtube.colors" value="FF000000|B2FF0000|FFFFFFFF|FF000000|FFC91313"/>
+        <setting type="Hybrid" target="com.google.android.apps.currents.colors" value="FFFFFFFF|FFFF4444|FFFF4444|FFFFFFFF|FFFF4444"/>
+
+</property>

--- a/prebuilt/pa/preferences/pa_nav_xhdpi/pref_1.xml
+++ b/prebuilt/pa/preferences/pa_nav_xhdpi/pref_1.xml
@@ -1,0 +1,16 @@
+<property name="Stock UI" active="true" image="/system/etc/paranoid/preferences/images/phone.png" color="#238fcd">
+
+        <description><![CDATA[
+            This will put your device into 320 DPI/360p Phone UI, none of your apps will be changed.
+        ]]></description>
+        <setting type="Hybrid" target="%hybrid_mode" value="1"/>
+        <setting type="Hybrid" target="com.android.systemui.dpi" value="%rom_default_dpi"/>
+        <setting type="Hybrid" target="com.android.systemui.layout" value="%rom_default_layout"/>
+        <setting type="Hybrid" target="com.android.systemui.navbar.dpi" value="100"/>
+        <setting type="Hybrid" target="com.android.systemui.statusbar.dpi" value="100"/>
+        <setting type="Hybrid" target="%system_default_layout" value="0"/>
+        <setting type="Hybrid" target="%system_default_dpi" value="0"/>
+        <setting type="Android" target="status_bar_show_clock" value="1"/>
+        <setting type="Android" target="max_notification_icons" value="5"/>
+
+</property>

--- a/prebuilt/pa/preferences/pa_nav_xhdpi/pref_2.xml
+++ b/prebuilt/pa/preferences/pa_nav_xhdpi/pref_2.xml
@@ -1,0 +1,16 @@
+<property name="Phablet UI" active="true" image="/system/etc/paranoid/preferences/images/phablet.png" color="#f4b122">
+
+        <description><![CDATA[
+            This will put your device into 225 DPI/600p Phablet UI, none of your apps will be changed.
+        ]]></description>
+        <setting type="Hybrid" target="%hybrid_mode" value="1"/>
+        <setting type="Hybrid" target="com.android.systemui.dpi" value="225"/>
+        <setting type="Hybrid" target="com.android.systemui.layout" value="600"/>
+        <setting type="Hybrid" target="com.android.systemui.navbar.dpi" value="100"/>
+        <setting type="Hybrid" target="com.android.systemui.statusbar.dpi" value="100"/>
+        <setting type="Hybrid" target="%system_default_layout" value="0"/>
+        <setting type="Hybrid" target="%system_default_dpi" value="0"/>
+        <setting type="Android" target="status_bar_show_clock" value="1"/>
+        <setting type="Android" target="max_notification_icons" value="5"/>
+
+</property>

--- a/prebuilt/pa/preferences/pa_nav_xhdpi/pref_3.xml
+++ b/prebuilt/pa/preferences/pa_nav_xhdpi/pref_3.xml
@@ -1,0 +1,16 @@
+<property name="Tablet UI" active="true" image="/system/etc/paranoid/preferences/images/tablet.png" color="#51ab27">
+
+        <description><![CDATA[
+            This will put your device into 192 DPI/1000p Tablet UI, none of your apps will be changed.
+        ]]></description>
+        <setting type="Hybrid" target="%hybrid_mode" value="1"/>
+        <setting type="Hybrid" target="com.android.systemui.dpi" value="192"/>
+        <setting type="Hybrid" target="com.android.systemui.layout" value="1000"/>
+        <setting type="Hybrid" target="com.android.systemui.navbar.dpi" value="100"/>
+        <setting type="Hybrid" target="com.android.systemui.statusbar.dpi" value="100"/>
+        <setting type="Hybrid" target="%system_default_layout" value="0"/>
+        <setting type="Hybrid" target="%system_default_dpi" value="0"/>
+        <setting type="Android" target="status_bar_show_clock" value="1"/>
+        <setting type="Android" target="max_notification_icons" value="5"/>
+
+</property>

--- a/prebuilt/pa/preferences/pa_nav_xhdpi/pref_4.xml
+++ b/prebuilt/pa/preferences/pa_nav_xhdpi/pref_4.xml
@@ -1,0 +1,16 @@
+<property name="Tablet UI" active="true" image="/system/etc/paranoid/preferences/images/tablet.png" color="#51ab27">
+
+        <description><![CDATA[
+            This will put your device into 220 DPI/1000p Tablet UI, none of your apps will be changed.
+        ]]></description>
+        <setting type="Hybrid" target="%hybrid_mode" value="1"/>
+        <setting type="Hybrid" target="com.android.systemui.dpi" value="220"/>
+        <setting type="Hybrid" target="com.android.systemui.layout" value="1000"/>
+        <setting type="Hybrid" target="com.android.systemui.navbar.dpi" value="100"/>
+        <setting type="Hybrid" target="com.android.systemui.statusbar.dpi" value="100"/>
+        <setting type="Hybrid" target="%system_default_layout" value="0"/>
+        <setting type="Hybrid" target="%system_default_dpi" value="0"/>
+        <setting type="Android" target="status_bar_show_clock" value="1"/>
+        <setting type="Android" target="max_notification_icons" value="2"/>
+
+</property>

--- a/prebuilt/pa/preferences/pa_nav_xhdpi/pref_5.xml
+++ b/prebuilt/pa/preferences/pa_nav_xhdpi/pref_5.xml
@@ -1,0 +1,16 @@
+<property name="Tablet UI" active="true" image="/system/etc/paranoid/preferences/images/tablet.png" color="#51ab27">
+
+        <description><![CDATA[
+            This will put your device into 250 DPI/1000p Tablet UI, none of your apps will be changed.
+        ]]></description>
+        <setting type="Hybrid" target="%hybrid_mode" value="1"/>
+        <setting type="Hybrid" target="com.android.systemui.dpi" value="250"/>
+        <setting type="Hybrid" target="com.android.systemui.layout" value="1000"/>
+        <setting type="Hybrid" target="com.android.systemui.navbar.dpi" value="100"/>
+        <setting type="Hybrid" target="com.android.systemui.statusbar.dpi" value="100"/>
+        <setting type="Hybrid" target="%system_default_layout" value="0"/>
+        <setting type="Hybrid" target="%system_default_dpi" value="0"/>
+        <setting type="Android" target="status_bar_show_clock" value="0"/>
+        <setting type="Android" target="max_notification_icons" value="2"/>
+
+</property>


### PR DESCRIPTION
This is needed to populate the hybrid properties ui and colors section when using the new pa_nav_xhdpi.conf.
