### PR TITLE
Correct Repo for use with the new Bootloader 

### DIFF
--- a/dependencies/p990.dependencies
+++ b/dependencies/p990.dependencies
@@ -1,7 +1,7 @@
 [
     {
         "remote":       "github",
-        "account":      "TheMuppets",
+        "account":      "PAC-lge",
         "repository":   "proprietary_vendor_lge",
         "target_path":  "vendor/lge",
         "revision":     "cm-10.1"


### PR DESCRIPTION
Must be use, if not, Rom can be stuck or malfunction, do not change
