### PR TITLE
Removed nav bar by default for xdhpi PhabletUI

### DIFF
--- a/prebuilt/pa/preferences/pa_xhdpi/pref_2.xml
+++ b/prebuilt/pa/preferences/pa_xhdpi/pref_2.xml
@@ -6,7 +6,7 @@
         <setting type="Hybrid" target="%hybrid_mode" value="1"/>
         <setting type="Hybrid" target="com.android.systemui.dpi" value="225"/>
         <setting type="Hybrid" target="com.android.systemui.layout" value="600"/>
-        <setting type="Hybrid" target="com.android.systemui.navbar.dpi" value="100"/>
+        <setting type="Hybrid" target="com.android.systemui.navbar.dpi" value="0"/>
         <setting type="Hybrid" target="com.android.systemui.statusbar.dpi" value="100"/>
         <setting type="Hybrid" target="%system_default_layout" value="0"/>
         <setting type="Hybrid" target="%system_default_dpi" value="0"/>


### PR DESCRIPTION
Edited pa_xhdpi/pref_2.xml to remove nav bar by default for Phablet UI since it is not required for devices using hardware buttons.
