### PR TITLE
Fix proprietary_vendor_htc link

### DIFF
--- a/dependencies/vision.dependencies
+++ b/dependencies/vision.dependencies
@@ -7,7 +7,7 @@
     },
   {
     "account":      "Pinky-Inky-and-Clyde",
-    "repository":   "proprietary_htc",
+    "repository":   "proprietary_vendor_htc",
     "target_path":  "vendor/htc",
     "revision":     "cm-11.0"
   },


### PR DESCRIPTION
Thanks for pulling the vision build together !
Just figured out that proprietary_htc seems to want to be proprietary_vendor_htc
